### PR TITLE
Throw error instead of using report.panic

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function (
 
       const result = await graphql(query);
       if (result.errors) {
-        report.panic(`failed to index to Algolia`, result.errors);
+        throw new Error(`failed to index to Algolia: ${result.errors}`);
       }
 
       const items = transformer(result).map(itemFormatter || ((item) => {


### PR DESCRIPTION
This is to address this open issue: https://github.com/u12206050/gridsome-plugin-algolia/issues/8

It looks like this line is using a dependency `report` that doesn't exist when it's trying to report an error with executing the query. This change uses `throw Error` instead, which matches the pattern that already exists.